### PR TITLE
fix(blog): correct article count display logic

### DIFF
--- a/src/components/sections/blog.tsx
+++ b/src/components/sections/blog.tsx
@@ -18,7 +18,7 @@ export interface BlogSectionProps {
 
 export const Blog = ({ blogs, tag }: BlogSectionProps) => {
     const heading = tag ? `📝 Blog: ${tag}` : '📝 Blog'
-    const articleCount = `${blogs.length} article${blogs.length > 1 && 's'}`
+    const articleCount = `${blogs.length} article${(blogs.length > 1 && 's') || ''}`
 
     return (
         <section className="flex flex-col space-y-8 pb-20 pt-4">


### PR DESCRIPTION
Hello, thank you for creating this great project. I've been basing my personal website off of yours. Thus, I've found a small mistake on the blog tag selection:

![image](https://github.com/user-attachments/assets/33ecc7aa-21bd-4d07-8683-e84c0fa7bf0e)

Resolving this issue is trivial as we only need to give an empty string as a return value instead of false. `blogs.length > 1 && 's') || ''`